### PR TITLE
ISSUE-335: locked solidity pragma to v0.5.11

### DIFF
--- a/src/DssAddIlkSpell.sol
+++ b/src/DssAddIlkSpell.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity 0.5.11;
 
 contract SpotterLike {
     function poke(bytes32) public;

--- a/src/DssAddIlkSpell.t.sol
+++ b/src/DssAddIlkSpell.t.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity 0.5.11;
 
 import "ds-test/test.sol";
 


### PR DESCRIPTION
Tests fail; however, tests were failing before this change.  We could merge this now, or we could block on it until we address https://github.com/makerdao/smart-contracts-team-pm/issues/350 and then update and merge it.  If we block on it, then we use the pressure to complete https://github.com/makerdao/smart-contracts-team-pm/issues/335 to also fix https://github.com/makerdao/smart-contracts-team-pm/issues/350.  If we merge it, there are likely no consequences other than we cannot confirm that tests still pass.  Either way, both issues must be resolved.
```
Running 3 tests for src/DssAddIlkSpell.t.sol:DssAddIlkSpellTest
[FAIL] testFlip()
[FAIL] testFrob()
[FAIL] testVariables()
```