### PR TITLE
Bump to 0.5.12 and set minimum

### DIFF
--- a/src/DssAddIlkSpell.sol
+++ b/src/DssAddIlkSpell.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity ^0.5.12;
 
 contract SpotterLike {
     function poke(bytes32) public;

--- a/src/DssAddIlkSpell.t.sol
+++ b/src/DssAddIlkSpell.t.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.11;
+pragma solidity ^0.5.12;
 
 import "ds-test/test.sol";
 


### PR DESCRIPTION
Bump this from `0.5.11` to `^0.5.12` to coincide with `dss` and only enforce minimum version since solc/dapptools versions are moving fast.